### PR TITLE
chore: cleanup from migration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @bradegler

--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ jobs:
       uses: 'actions/checkout@v3'
     -
       name: 'secure-setup-terraform'
-      uses: 'bradegler/secure-setup-terraform@v0.0.10'
+      uses: 'abcxyz/secure-setup-terraform@v0.1.0'
       with:
-        terraform_version: '1.3.2'
-        terraform_checksum: '${{ secrets.TERRAFORM_CHECKSUM }}'
+        terraform_version: '1.3.3'
     ## Use terraform normally
 ```
 

--- a/cmd/lint-action/main.go
+++ b/cmd/lint-action/main.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/bradegler/secure-setup-terraform/pkg/linter"
-	"github.com/bradegler/secure-setup-terraform/pkg/version"
+	"github.com/abcxyz/secure-setup-terraform/pkg/linter"
+	"github.com/abcxyz/secure-setup-terraform/pkg/version"
 )
 
 const lintCommandHelp = `

--- a/cmd/lint-terraform/main.go
+++ b/cmd/lint-terraform/main.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/bradegler/secure-setup-terraform/pkg/linter"
-	"github.com/bradegler/secure-setup-terraform/pkg/version"
+	"github.com/abcxyz/secure-setup-terraform/pkg/linter"
+	"github.com/abcxyz/secure-setup-terraform/pkg/version"
 )
 
 const lintCommandHelp = `

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bradegler/secure-setup-terraform
+module github.com/abcxyz/secure-setup-terraform
 
 go 1.18
 


### PR DESCRIPTION
removed references to development repository as part of migration to abczyx