### PR TITLE
fix: hardcoded version, example location

### DIFF
--- a/.github/actions/secure-setup-terraform/action.yml
+++ b/.github/actions/secure-setup-terraform/action.yml
@@ -53,7 +53,7 @@ runs:
       name: 'verify-binary-checksum'
       shell: 'bash'
       run: |-
-        CHECKSUM=$(jq -r '.versions[] | select(.version=="1.3.3" and .arch=="amd64" and .os=="linux") | .binary_checksum' < terraform-checksums.json)
+        CHECKSUM=$(jq -r --arg version ${{ inputs.terraform_version }} '.versions[] | select(.version==$version and .arch=="amd64" and .os=="linux") | .binary_checksum' < terraform-checksums.json)
         echo "${CHECKSUM}  $(which terraform)" > terraform.sha256
         shasum --algorithm 256 --check terraform.sha256
 

--- a/example/verify-secure-terraform.yml
+++ b/example/verify-secure-terraform.yml
@@ -19,7 +19,7 @@ on:
     inputs:
       terraform_version:
         type: string
-        description: Terraform version (e.g 1.3.2)
+        description: Terraform version (e.g 1.3.3)
         required: false
         default: '1.3.3'
 


### PR DESCRIPTION
Replaced hardcoded version information with correct reference to input value. Moved the example workflow out of the .github/workflows folder into an 'examples' folder.