### PR TITLE
feat: Added automation for generating checksums

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default fallback
-* @sethvargo
+* @abcxyz/breakglass
 
 # github-actions owns all files
 *    @abcxyz/github-actions

--- a/.github/workflows/update-checksums.yml
+++ b/.github/workflows/update-checksums.yml
@@ -1,0 +1,44 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Update Checksums File'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 */1 * *'
+
+jobs:
+  update-checksums:
+    permissions:
+      contents: 'write'
+      packages: 'write'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - id: 'checkout'
+        uses: 'actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8' # ratchet:actions/checkout@v3
+      # Generate updates to the checksum file if there are new released versions of terraform
+      - id: 'generate-updates'
+        run: './.github/generate_version_checksums.sh;'
+      # Create a pull request for review
+      - id: 'create-pull-request'
+        if: ${{ env.CHANGES }}
+        uses: peter-evans/create-pull-request@b4d51739f96fca8047ad065eccef63442d8e99f7 # ratchet:peter-evans/create-pull-request@v4
+        with:
+          add-paths: 'terraform-checksums.json'
+          commit-message: 'chore: [automated] checksum updates'
+          delete-branch: true
+          branch: '${{ env.PR_BRANCH }}'
+          title: 'chore: Terraform checksum updates for ${{ env.UPDATE_DATE }}'
+          body: |-
+            Adds Terraform binary checksums for ${{ env.CHANGES }} versions: ${{ env.VERSIONS }}


### PR DESCRIPTION
Created a GitHub workflow that will run nightly to look for new Terraform release versions.

If it finds new versions it will:

* Generate a new terraform-checksums.json file

* Submit a pull request for review