### PR TITLE
fix: Path to checksum file was relative and it caused issues when run from the action workflow

### DIFF
--- a/.github/generate_version_checksums.sh
+++ b/.github/generate_version_checksums.sh
@@ -1,11 +1,16 @@
 #!/bin/sh
 
+checksum_file=$1
+if [ "${checksum_file}" = "" ];
+then
+    echo "Usage: $0 <path to checkums file>";
+    exit 1;
+fi;
+
 mkdir -p temp
 cd temp || exit
 
 export GNUPGHOME=./.gnupg;
-
-checksum_file=../terraform-checksums.json
 
 # Generate a temporary key to use for verification
 gpg --batch --quick-generate-key --batch --passphrase "" github-action@abcxyz.dev;

--- a/.github/generate_version_checksums.sh
+++ b/.github/generate_version_checksums.sh
@@ -5,7 +5,7 @@ cd temp || exit
 
 export GNUPGHOME=./.gnupg;
 
-checksum_file=../../terraform-checksums.json
+checksum_file=../terraform-checksums.json
 
 # Generate a temporary key to use for verification
 gpg --batch --quick-generate-key --batch --passphrase "" github-action@abcxyz.dev;

--- a/.github/workflows/update-checksums.yml
+++ b/.github/workflows/update-checksums.yml
@@ -29,7 +29,7 @@ jobs:
         uses: 'actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8' # ratchet:actions/checkout@v3
       # Generate updates to the checksum file if there are new released versions of terraform
       - id: 'generate-updates'
-        run: './.github/generate_version_checksums.sh;'
+        run: './.github/generate_version_checksums.sh $GITHUB_WORKSPACE/terraform-checksums.json;'
       # Create a pull request for review
       - id: 'create-pull-request'
         if: ${{ env.CHANGES }}


### PR DESCRIPTION
When running in a workflow, the generate_version_checksums.sh was being executed from the root of the workspace which caused the relative path to be incorrect.

Changed the main script to accept the checksum file as a parameter and updated the workflow to pass the fully qualified path.