### PR TITLE
fix: checksum workflow permissions

### DIFF
--- a/.github/workflows/update-checksums.yml
+++ b/.github/workflows/update-checksums.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: 'write'
       packages: 'write'
+      pull-requests: 'write'
     runs-on: 'ubuntu-latest'
     steps:
       - id: 'checkout'


### PR DESCRIPTION
Checksum maintenance workflow did not have permission to create a new pull request.