### PR TITLE
feat: added provider file locking 

### DIFF
--- a/.github/actions/secure-setup-terraform/action.yml
+++ b/.github/actions/secure-setup-terraform/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: 'The terraform version to install'
     default: '1.3.3'
     required: false
+  terraform_lockfile_location:
+    description: 'Path to the directory containing the .terraform.lock.hcl file. This action will mark this file readonly to prevent terraform init calls from adding new providers.'
+    required: true
 
 runs:
   using: 'composite'
@@ -56,5 +59,8 @@ runs:
         CHECKSUM=$(jq -r --arg version ${{ inputs.terraform_version }} '.versions[] | select(.version==$version and .arch=="amd64" and .os=="linux") | .binary_checksum' < terraform-checksums.json)
         echo "${CHECKSUM}  $(which terraform)" > terraform.sha256
         shasum --algorithm 256 --check terraform.sha256
+    - name: 'lock-provider-file'
+      shell: 'bash'
+      run: 'chmod 444 ${{ inputs.terraform_lockfile_location }}/.terraform.lock.hcl'
 
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ jobs:
       uses: 'abcxyz/secure-setup-terraform@v0.1.0'
       with:
         terraform_version: '1.3.3'
+        terraform_lockfile_location: './terraform/modules'
     ## Use terraform normally
 ```
 


### PR DESCRIPTION
Marking the file readonly which will cause terraform init to fail if new providers are added