### PR TITLE
Updates to allow use of terraform wrapper

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: 'download-artifacts'
       shell: 'bash'
       env:
-        RELEASE_VERSION: '0.2.2'
+        RELEASE_VERSION: '0.2.3'
         RELEASE_LOCATION: 'https://github.com/abcxyz/secure-setup-terraform/releases/download'
       run: |-
         curl -H "Authorization: token ${{ github.token }}" -LO "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_amd64.tar.gz"

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   terraform_lockfile_location:
     description: 'Path to the directory containing the .terraform.lock.hcl file. This action will mark this file readonly to prevent terraform init calls from adding new providers.'
     required: false
-    default: './'
+    default: '.'
   terraform_use_wrapper:
     description: 'Allow the setup-terraform action to install the wrapper'
     required: false
@@ -37,7 +37,7 @@ runs:
     - name: 'download-artifacts'
       shell: 'bash'
       env:
-        RELEASE_VERSION: '0.2.2'
+        RELEASE_VERSION: '0.2.3'
         RELEASE_LOCATION: 'https://github.com/abcxyz/secure-setup-terraform/releases/download'
       run: |-
         curl -H "Authorization: token ${{ github.token }}" -LO "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_amd64.tar.gz"

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,7 @@ runs:
         then
           ARCH="arm6"
         fi
+        echo "Running on ${ARCH}"
 
         curl -H "Authorization: token ${{ github.token }}" -LO "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_${ARCH}.tar.gz"
         curl -H "Authorization: token ${{ github.token }}" -Lo terraform-checksums.json "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_checksums.json"

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: 'secure-terraform'
       shell: 'bash'
       env:
-        RELEASE_VERSION: '0.2.3'
+        RELEASE_VERSION: '0.2.2'
         RELEASE_LOCATION: 'https://github.com/abcxyz/secure-setup-terraform/releases/download'
       run: |-
         ARCH="amd6";

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,8 @@ runs:
         else
           echo "${CHECKSUM}  $(which terraform)" > terraform.sha256
         fi
+        echo "TF CHECKSUM"
+        cat terraform.sha256
         shasum --algorithm 256 --check terraform.sha256
 
     # Recursively search for terraform files in the current repo and run a linter that fails when it finds calls to 'local-exec'

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
         tar xf secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_${ARCH}.tar.gz
         
         # Verify the terraform binary checksum
-        CHECKSUM=$(jq -r --arg version ${{ inputs.terraform_version }} '.versions[] | select(.version==$version and .arch=="${ARCH}" and .os=="linux") | .binary_checksum' < terraform-checksums.json)
+        CHECKSUM=$(jq -r --arg version ${{ inputs.terraform_version }} '.versions[] | select(.version==$version and .arch=="'${ARCH}'" and .os=="linux") | .binary_checksum' < terraform-checksums.json)
 
         # The terraform wrapper installs the actual binary as terraform-bin, check 
         # for its existence and verify its checksum. Otherwise look for the default

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,7 @@ runs:
       uses: 'hashicorp/setup-terraform@v2'
       with:
         terraform_version: '${{ inputs.terraform_version }}'
+        terraform_wrapper: false
     - 
       name: 'verify-binary-checksum'
       shell: 'bash'

--- a/action.yml
+++ b/action.yml
@@ -52,12 +52,11 @@ runs:
         RELEASE_VERSION: '0.2.2'
         RELEASE_LOCATION: 'https://github.com/abcxyz/secure-setup-terraform/releases/download'
       run: |-
-        ARCH="amd6";
+        ARCH="amd64";
         if [ "${{runner.platform}}" = "ARM64" ];
         then
-          ARCH="arm6"
+          ARCH="arm64"
         fi
-        echo "Running on ${ARCH}"
 
         curl -H "Authorization: token ${{ github.token }}" -LO "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_${ARCH}.tar.gz"
         curl -H "Authorization: token ${{ github.token }}" -Lo terraform-checksums.json "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_checksums.json"

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: 'download-artifacts'
       shell: 'bash'
       env:
-        RELEASE_VERSION: '0.2.3'
+        RELEASE_VERSION: '0.2.2'
         RELEASE_LOCATION: 'https://github.com/abcxyz/secure-setup-terraform/releases/download'
       run: |-
         curl -H "Authorization: token ${{ github.token }}" -LO "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_amd64.tar.gz"

--- a/action.yml
+++ b/action.yml
@@ -30,19 +30,51 @@ inputs:
   cli_config_credentials_token:
     description: 'From setup-terraform: The API token for a Terraform Cloud/Enterprise instance to place within the credentials block of the Terraform CLI configuration file.'
     required: false
+  terraform_lockfile_location:
+    description: 'Path to the directory containing the .terraform.lock.hcl file. This action will mark this file readonly to prevent terraform init calls from adding new providers.'
+    required: false
+    default: '.'
 
 runs:
   using: 'composite'
   steps:
-    - name: 'download-artifacts'
+    - name: 'setup-terraform'
+      uses: 'hashicorp/setup-terraform@v2'
+      with:
+        terraform_version: '${{ inputs.terraform_version }}'
+        terraform_wrapper: '${{ inputs.terraform_wrapper }}'
+        cli_config_credentials_hostname: '${{ inputs.cli_config_credentials_hostname }}'
+        cli_config_credentials_token: '${{ inputs.cli_config_credentials_token }}'
+
+    - name: 'secure-terraform'
       shell: 'bash'
       env:
         RELEASE_VERSION: '0.2.3'
         RELEASE_LOCATION: 'https://github.com/abcxyz/secure-setup-terraform/releases/download'
       run: |-
-        curl -H "Authorization: token ${{ github.token }}" -LO "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_amd64.tar.gz"
+        ARCH="amd6";
+        if [ "${{runner.platform}}" = "ARM64" ];
+        then
+          ARCH="arm6"
+        fi
+
+        curl -H "Authorization: token ${{ github.token }}" -LO "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_${ARCH}.tar.gz"
         curl -H "Authorization: token ${{ github.token }}" -Lo terraform-checksums.json "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_checksums.json"
-        tar xf secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_amd64.tar.gz
+        tar xf secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_${ARCH}.tar.gz
+        
+        # Verify the terraform binary checksum
+        CHECKSUM=$(jq -r --arg version ${{ inputs.terraform_version }} '.versions[] | select(.version==$version and .arch=="${ARCH}" and .os=="linux") | .binary_checksum' < terraform-checksums.json)
+
+        # The terraform wrapper installs the actual binary as terraform-bin, check 
+        # for its existence and verify its checksum. Otherwise look for the default
+        # terrafrom binary
+        if [ -f "$(which terraform-bin)" ];
+        then
+          echo "${CHECKSUM}  $(which terraform-bin)" > terraform.sha256
+        else
+          echo "${CHECKSUM}  $(which terraform)" > terraform.sha256
+        fi
+        shasum --algorithm 256 --check terraform.sha256
 
     # Recursively search for terraform files in the current repo and run a linter that fails when it finds calls to 'local-exec'
     - name: 'lint-terraform'
@@ -54,22 +86,7 @@ runs:
       shell: 'bash'
       run: ./lint-action ./.github/workflows
 
-    - name: 'setup-terraform'
-      uses: 'hashicorp/setup-terraform@v2'
-      with:
-        terraform_version: '${{ inputs.terraform_version }}'
-        terraform_wrapper: '${{ inputs.terraform_wrapper }}'
-        cli_config_credentials_hostname: '${{ inputs.cli_config_credentials_hostname }}'
-        cli_config_credentials_token: '${{ inputs.cli_config_credentials_token }}'
-    - 
-      name: 'verify-binary-checksum'
+    # Mark the provider file readonly so that new providers cannot be added during actuation
+    - name: 'lock-provider-file'
       shell: 'bash'
-      run: |-
-        CHECKSUM=$(jq -r --arg version ${{ inputs.terraform_version }} '.versions[] | select(.version==$version and .arch=="amd64" and .os=="linux") | .binary_checksum' < terraform-checksums.json)
-        if "${{ inputs.terraform_wrapper }}" = "true"; 
-        then
-          echo "${CHECKSUM}  $(which terraform-bin)" > terraform.sha256
-        else
-          echo "${CHECKSUM}  $(which terraform)" > terraform.sha256
-        fi
-        shasum --algorithm 256 --check terraform.sha256
+      run: 'chmod 444 ${{ inputs.terraform_lockfile_location }}/.terraform.lock.hcl'

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,6 @@ runs:
       env:
         RELEASE_VERSION: '0.2.2'
         RELEASE_LOCATION: 'https://github.com/abcxyz/secure-setup-terraform/releases/download'
-        USE_WRAPPER: ${{inputs.terraform_wrapper}}
       run: |-
         ARCH="amd64";
         if [ "${{runner.platform}}" = "ARM64" ];
@@ -69,14 +68,12 @@ runs:
         # The terraform wrapper installs the actual binary as terraform-bin, check 
         # for its existence and verify its checksum. Otherwise look for the default
         # terrafrom binary
-        if [ "${{env.USE_WRAPPER}}" = "true" ];
+        if [ -f "$(which terrafrom-bin)" ];
         then
           echo "${CHECKSUM}  $(which terraform-bin)" > terraform.sha256
         else
           echo "${CHECKSUM}  $(which terraform)" > terraform.sha256
         fi
-        echo "TF CHECKSUM"
-        cat terraform.sha256
         shasum --algorithm 256 --check terraform.sha256
 
     # Recursively search for terraform files in the current repo and run a linter that fails when it finds calls to 'local-exec'

--- a/action.yml
+++ b/action.yml
@@ -16,19 +16,24 @@ name: 'secure-setup-terraform action'
 description: 'Verify that the installed terraform binary matches a pre-computed hash. Ensure that there is a checked in provider lock file and that it is read only so that terraform cannot update it.'
 inputs:
   terraform_version:
-    description: 'The terraform version to install'
-    default: '1.3.3'
+    description: 'The version of Terraform CLI to install. Instead of full version string you can also specify constraint string starting with "<" (for example `<1.13.0`) to install the latest version satisfying the constraint. A value of `latest` will install the latest version of Terraform CLI. Defaults to `latest`.'
+    default: 'latest'
     required: false
-  terraform_use_wrapper:
-    description: 'Allow the setup-terraform action to install the wrapper'
-    required: false
+  terraform_wrapper:
+    description: 'Whether or not to install a wrapper to wrap subsequent calls of the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`.'
     default: 'true'
+    required: false
+  cli_config_credentials_hostname:
+    description: 'From setup-terraform: The hostname of a Terraform Cloud/Enterprise instance to place within the credentials block of the Terraform CLI configuration file. Defaults to `app.terraform.io`.'
+    default: 'app.terraform.io'
+    required: false
+  cli_config_credentials_token:
+    description: 'From setup-terraform: The API token for a Terraform Cloud/Enterprise instance to place within the credentials block of the Terraform CLI configuration file.'
+    required: false
 
 runs:
   using: 'composite'
   steps:
-    - name: 'checkout'
-      uses: 'actions/checkout@v3'
     - name: 'download-artifacts'
       shell: 'bash'
       env:
@@ -53,13 +58,15 @@ runs:
       uses: 'hashicorp/setup-terraform@v2'
       with:
         terraform_version: '${{ inputs.terraform_version }}'
-        terraform_wrapper: '${{ inputs.terraform_use_wrapper }}'
+        terraform_wrapper: '${{ inputs.terraform_wrapper }}'
+        cli_config_credentials_hostname: '${{ inputs.cli_config_credentials_hostname }}'
+        cli_config_credentials_token: '${{ inputs.cli_config_credentials_token }}'
     - 
       name: 'verify-binary-checksum'
       shell: 'bash'
       run: |-
         CHECKSUM=$(jq -r --arg version ${{ inputs.terraform_version }} '.versions[] | select(.version==$version and .arch=="amd64" and .os=="linux") | .binary_checksum' < terraform-checksums.json)
-        if "${{ inputs.terraform_use_wrapper }}" = "true"; 
+        if "${{ inputs.terraform_wrapper }}" = "true"; 
         then
           echo "${CHECKSUM}  $(which terraform-bin)" > terraform.sha256
         else

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
     default: './'
   terraform_use_wrapper:
-    description: 'All the setup-terraform action to install the wrapper'
+    description: 'Allow the setup-terraform action to install the wrapper'
     required: false
     default: 'true'
 
@@ -64,7 +64,7 @@ runs:
       shell: 'bash'
       run: |-
         CHECKSUM=$(jq -r --arg version ${{ inputs.terraform_version }} '.versions[] | select(.version==$version and .arch=="amd64" and .os=="linux") | .binary_checksum' < terraform-checksums.json)
-        if ${{ inputs.terraform_use_wrapper }} == "true"; 
+        if "${{ inputs.terraform_use_wrapper }}" = "true"; 
         then
           echo "${CHECKSUM}  $(which terraform-bin)" > terraform.sha256
         else

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,13 @@ inputs:
     required: false
   terraform_lockfile_location:
     description: 'Path to the directory containing the .terraform.lock.hcl file. This action will mark this file readonly to prevent terraform init calls from adding new providers.'
-    required: true
+    required: false
+    default: './'
+  terraform_use_wrapper:
+    description: 'All the setup-terraform action to install the wrapper'
+    required: false
+    default: 'true'
+
 
 runs:
   using: 'composite'
@@ -52,13 +58,18 @@ runs:
       uses: 'hashicorp/setup-terraform@v2'
       with:
         terraform_version: '${{ inputs.terraform_version }}'
-        terraform_wrapper: false
+        terraform_wrapper: '${{ inputs.terraform_use_wrapper }}'
     - 
       name: 'verify-binary-checksum'
       shell: 'bash'
       run: |-
         CHECKSUM=$(jq -r --arg version ${{ inputs.terraform_version }} '.versions[] | select(.version==$version and .arch=="amd64" and .os=="linux") | .binary_checksum' < terraform-checksums.json)
-        echo "${CHECKSUM}  $(which terraform)" > terraform.sha256
+        if ${{ inputs.terraform_use_wrapper }} == "true"; 
+        then
+          echo "${CHECKSUM}  $(which terraform-bin)" > terraform.sha256
+        else
+          echo "${CHECKSUM}  $(which terraform)" > terraform.sha256
+        fi
         shasum --algorithm 256 --check terraform.sha256
     - name: 'lock-provider-file'
       shell: 'bash'

--- a/action.yml
+++ b/action.yml
@@ -19,15 +19,10 @@ inputs:
     description: 'The terraform version to install'
     default: '1.3.3'
     required: false
-  terraform_lockfile_location:
-    description: 'Path to the directory containing the .terraform.lock.hcl file. This action will mark this file readonly to prevent terraform init calls from adding new providers.'
-    required: false
-    default: '.'
   terraform_use_wrapper:
     description: 'Allow the setup-terraform action to install the wrapper'
     required: false
     default: 'true'
-
 
 runs:
   using: 'composite'
@@ -71,8 +66,3 @@ runs:
           echo "${CHECKSUM}  $(which terraform)" > terraform.sha256
         fi
         shasum --algorithm 256 --check terraform.sha256
-    - name: 'lock-provider-file'
-      shell: 'bash'
-      run: 'chmod 444 ${{ inputs.terraform_lockfile_location }}/.terraform.lock.hcl'
-
-

--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
         # The terraform wrapper installs the actual binary as terraform-bin, check 
         # for its existence and verify its checksum. Otherwise look for the default
         # terrafrom binary
-        if [ -f "$(which terraform-bin)" ];
+        if [ "${{inputs.terraform_wrapper}}" = "true" ];
         then
           echo "${CHECKSUM}  $(which terraform-bin)" > terraform.sha256
         else

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,7 @@ runs:
       env:
         RELEASE_VERSION: '0.2.2'
         RELEASE_LOCATION: 'https://github.com/abcxyz/secure-setup-terraform/releases/download'
+        USE_WRAPPER: ${{inputs.terraform_wrapper}}
       run: |-
         ARCH="amd64";
         if [ "${{runner.platform}}" = "ARM64" ];
@@ -68,7 +69,7 @@ runs:
         # The terraform wrapper installs the actual binary as terraform-bin, check 
         # for its existence and verify its checksum. Otherwise look for the default
         # terrafrom binary
-        if [ "${{inputs.terraform_wrapper}}" = "true" ];
+        if [ "${{env.USE_WRAPPER}}" = "true" ];
         then
           echo "${CHECKSUM}  $(which terraform-bin)" > terraform.sha256
         else


### PR DESCRIPTION
'hashicorp/setup-terraform' has the ability to wrap the terraform binary in a bit of javascript which sets specific output variables that are usable by downstream GitHub actions.