### PR TITLE
chore: [manual] checksum updates

### DIFF
--- a/terraform-checksums.json
+++ b/terraform-checksums.json
@@ -671,6 +671,20 @@
       "binary_checksum": "5fc435072a9d88cd7c4fe518dcbc538c1c07a4500ee818d58a7f8440bcca358f",
       "os": "linux",
       "arch": "arm64"
+    },
+    {
+      "version": "1.4.6",
+      "archive_checksum": "e079db1a8945e39b1f8ba4e513946b3ab9f32bd5a2bdf19b9b186d22c5a3d53b",
+      "binary_checksum": "84f8bd27772df3d7b12059c00aad35695f29a1bd40f6610a0c54003f7d93f18d",
+      "os": "linux",
+      "arch": "amd64"
+    },
+    {
+      "version": "1.4.6",
+      "archive_checksum": "b38f5db944ac4942f11ceea465a91e365b0636febd9998c110fbbe95d61c3b26",
+      "binary_checksum": "a4a478890ce0ca4764463f0488999b085398dba0d88fd7760bbfcee4eeb1c84b",
+      "os": "linux",
+      "arch": "arm64"
     }
   ]
 }


### PR DESCRIPTION
Adds Terraform binary checksums for 1 versions: 1.4.6