### PR TITLE
fix: updated to use global environment variables for token-minter

### DIFF
--- a/.github/workflows/update-checksums.yml
+++ b/.github/workflows/update-checksums.yml
@@ -37,10 +37,10 @@ jobs:
         if: '${{ env.CHANGES }}'
         uses: 'abcxyz/github-token-minter/.github/actions/mint-token@4e83d0b3f01f2b084dbbd3c6da07b29a2c032c6e'
         with:
-          wif_provider: '${{ vars.GHTM_WIF_PROVIDER }}'
-          wif_service_account: '${{ vars.GHTM_WIF_SERVICE_ACCOUNT }}'
-          service_audience: '${{ vars.GHTM_SERVICE_AUDIENCE }}'
-          service_url: '${{ vars.GHTM_SERVICE_URL }}'
+          wif_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
+          wif_service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
+          service_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
+          service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
           requested_permissions: '{"repositories":["secure-setup-terraform"],"permissions":{"pull_requests":"write","contents":"write"}}'
       # Create a pull request for review
       - id: 'create-pull-request'


### PR DESCRIPTION
Current repository has local environment variables set for accessing github-token-minter.

These variables were not updated during the production migration which caused the "update checksums" workflow to fail because it could not reach the old production service which was shutdown.