### PR TITLE
chore: update actions deps

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       version: '${{ steps.version.outputs.version }}'
     steps:
-      - uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
+      - uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
 
       - id: 'version'
         run: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,15 +26,15 @@ jobs:
       packages: 'write'
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
+      - uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: 'actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491' # ratchet:actions/setup-go@v5
+      - uses: 'actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7' # ratchet:actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
-      - uses: 'goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8' # ratchet:goreleaser/goreleaser-action@v5
+      - uses: 'goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200' # ratchet:goreleaser/goreleaser-action@v6
         with:
           version: 'v1.12.3'
           args: 'release --rm-dist'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     uses: 'abcxyz/pkg/.github/workflows/yaml-lint.yml@main' # ratchet:exclude
 
   go_lint:
-    uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@cec59ae65591e7f2293aba3c50a8cb19076269c0' # ratchet:abcxyz/pkg/.github/workflows/go-lint.yml@main
+    uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@e6295e3016161bf062cabbf9b245603652923669' # ratchet:abcxyz/pkg/.github/workflows/go-lint.yml@main
 
   go_test:
-    uses: 'abcxyz/pkg/.github/workflows/go-test.yml@cec59ae65591e7f2293aba3c50a8cb19076269c0' # ratchet:abcxyz/pkg/.github/workflows/go-test.yml@main
+    uses: 'abcxyz/pkg/.github/workflows/go-test.yml@e6295e3016161bf062cabbf9b245603652923669' # ratchet:abcxyz/pkg/.github/workflows/go-test.yml@main

--- a/.github/workflows/update-checksums.yml
+++ b/.github/workflows/update-checksums.yml
@@ -29,7 +29,7 @@ jobs:
 
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
+      - uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
 
       # Generate updates to the checksum file if there are new released versions of terraform
       - name: 'Generate Updates'

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
   using: 'composite'
   steps:
     - name: 'setup-terraform'
-      uses: 'hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1' # ratchet:hashicorp/setup-terraform@v2
+      uses: 'hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8' # ratchet:hashicorp/setup-terraform@v3
       with:
         terraform_version: '${{ inputs.terraform_version }}'
         terraform_wrapper: '${{ inputs.terraform_wrapper }}'


### PR DESCRIPTION
This will remove warnings about outdated nodejs version on hashicorp/setup-terraform.