### PR TITLE
fix: script had bad interpreter path due to changes for linting

### DIFF
--- a/.github/generate_version_checksums.sh
+++ b/.github/generate_version_checksums.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env/bash
+#!/bin/bash
 
 set -euo pipefail
 


### PR DESCRIPTION
Linting changes introduced in #158 changed the shell on the script from the universally available `/bin/sh` to `/usr/bin/env/bash` which does not exist. 

This change points the script to `/bin/bash` which should exist in GHA.