### PR TITLE
fix: faulty logic update causes script to always display usage information

### DIFF
--- a/.github/generate_version_checksums.sh
+++ b/.github/generate_version_checksums.sh
@@ -5,11 +5,17 @@ set -euo pipefail
 # Expected to be run in github actions context.
 declare -r GITHUB_ENV
 
-checksum_file="${1}"
-if [[ -n "${checksum_file}" ]]; then
+
+if [[ "$#" -ne 1 ]]; then
+    echo "Invalid number of arguments specified - expected 1, received $#"
+    echo "-> $*"
+    echo
     echo "Usage: $0 <path to checkums file>";
+    echo
     exit 1;
 fi;
+
+checksum_file="${1}"
 
 mkdir -p temp
 cd temp || exit


### PR DESCRIPTION
Updates for linting changed the logic from `[ "$checksum_file" = ""]` which is true when there is no filename as the first argument to `[[ -n "${checksum_file}" ]]` which is true when there **is** a filename as the first argument. This is the reverse of the original logic and causes the script to always fail.

I changed the logic to be a test on the number of arguments instead of testing the length of a string in arg position 1. This will catch additional errors where callers may attempt to call this with extra arguments thinking that it can support multiple checksum files.
