### PR TITLE
chore: support windows with both the binary and action

### DIFF
--- a/.github/generate_version_checksums.sh
+++ b/.github/generate_version_checksums.sh
@@ -57,35 +57,34 @@ do
         curl -s --remote-name "${release_url}/${version}/${sha_file}";
         curl -s --remote-name "${release_url}/${version}/${sig_file}";
 
-        # Iterate over both supported architectures
-        set -- amd64 arm64;
-        for arch in "$@";
+        for os in linux darwin windows;
         do
-            bin_url=$(jq -r --arg arch "${arch}" '.builds[] | select(.os=="linux" and .arch==$arch) | .url' < "${version_file}");
-            bin_file=$(jq -r --arg arch "${arch}" '.builds[] | select(.os=="linux" and .arch==$arch) | .filename' < "${version_file}");
-            # Download the archive, sha file and signature
-            curl -s --remote-name "${bin_url}"
+            for arch in amd64 arm64;
+            do
+                exists_build=$(jq -r --arg os "${os}" --arg arch "${arch}" '.builds[] | select(.os==$os and .arch==$arch) | .filename' < "${version_file}" 2>/dev/null || true)
+                if [[ -n "${exists_build}" ]]; then
+                    bin_url=$(jq -r --arg os "${os}" --arg arch "${arch}" '.builds[] | select(.os==$os and .arch==$arch) | .url' < "${version_file}")
+                    bin_file=$(jq -r --arg os "${os}" --arg arch "${arch}" '.builds[] | select(.os==$os and .arch==$arch) | .filename' < "${version_file}")
+                    curl -s --remote-name "${bin_url}"
 
-            # Verify the signature against the sha file
-            gpg --batch --verify "${sig_file}" "${sha_file}";
+                    gpg --batch --verify "${sig_file}" "${sha_file}";
+                    shasum --algorithm 256 --check --ignore-missing "${sha_file}";
+                    unzip -qq -o "${bin_file}";
+                    arch_sum=$(grep "${bin_file}" "${sha_file}" | cut -d' ' -f1);
 
-            # Verify the archive's checksum
-            shasum --algorithm 256 --check --ignore-missing "${sha_file}";
+                    binary_name="terraform"
+                    if [[ "${os}" = "windows" ]]; then
+                        binary_name="terraform.exe"
+                    fi
+                    bin_sum=$(shasum -a 256 "${binary_name}" | cut -d' ' -f1);
+                    rm -f "${binary_name}"
 
-            # Extract the binary from the archive
-            unzip -qq -o "${bin_file}";
-
-            # Extract only the shasum for the archive we care about
-            arch_sum=$(grep "${bin_file}" "${sha_file}" | cut -d' ' -f1);
-
-            # Produce a checksum of the binary
-            bin_sum=$(shasum -a 256 terraform | cut -d' ' -f1);
-
-            version_info=$(jq -c -n --arg version "${version}" --arg archive_checksum "${arch_sum}" --arg binary_checksum "${bin_sum}" --arg os "linux" --arg arch "${arch}" '$ARGS.named');
-            jq --argjson version_info "${version_info}" '.versions += [$version_info]' < "${checksum_file}" > updated.json;
-            mv updated.json "${checksum_file}";
-
-        done;
+                    version_info=$(jq -c -n --arg version "${version}" --arg archive_checksum "${arch_sum}" --arg binary_checksum "${bin_sum}" --arg os "${os}" --arg arch "${arch}" '$ARGS.named');
+                    jq --argjson version_info "${version_info}" '.versions += [$version_info]' < "${checksum_file}" > updated.json;
+                    mv updated.json "${checksum_file}";
+                fi
+            done
+        done
 
         echo "${version}" >> "${added_file}";
     fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,40 @@ concurrency:
 
 jobs:
   go_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - 'ubuntu-latest'
+          - 'windows-latest'
+          - 'macos-latest'
     uses: 'abcxyz/actions/.github/workflows/go-test.yml@main' # ratchet:exclude
+    with:
+      runs-on: '"${{ matrix.os }}"'
+
+  action_test:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - 'ubuntu-latest'
+          - 'windows-latest'
+          - 'macos-latest'
+        terraform_version:
+          - '1.7.1'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+
+      - name: 'Setup Go'
+        uses: 'actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b' # ratchet:actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: 'Run action'
+        uses: './'
+        with:
+          terraform_version: '${{ matrix.terraform_version }}'
+          terraform_module_location: './example'
+          protect_lockfile: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  contents: 'read'
+
 jobs:
   go_test:
     strategy:
@@ -47,8 +50,9 @@ jobs:
       matrix:
         os:
           - 'ubuntu-latest'
-          - 'windows-latest'
-          - 'macos-latest'
+          # TODO: add back after releasing checksums for these env.
+          # - 'windows-latest'
+          # - 'macos-latest'
         terraform_version:
           - '1.7.1'
     steps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,6 +44,7 @@ builds:
     goos:
       - 'darwin'
       - 'linux'
+      - 'windows'
     goarch:
       - 'amd64'
       - 'arm64'
@@ -65,6 +66,7 @@ builds:
     goos:
       - 'darwin'
       - 'linux'
+      - 'windows'
     goarch:
       - 'amd64'
       - 'arm64'

--- a/action.yml
+++ b/action.yml
@@ -61,26 +61,73 @@ runs:
         RELEASE_LOCATION: 'https://github.com/abcxyz/secure-setup-terraform/releases/download'
       run: |-
         ARCH="amd64";
-        if [ "${{runner.platform}}" = "ARM64" ];
+        RUNNER_ARCH="${{ runner.arch || runner.platform }}"
+        if [ "${RUNNER_ARCH}" = "ARM64" ] || [ "${RUNNER_ARCH}" = "arm64" ];
         then
           ARCH="arm64"
         fi
 
-        curl -H "Authorization: token ${{ github.token }}" -LO "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_${ARCH}.tar.gz"
-        curl -H "Authorization: token ${{ github.token }}" -Lo terraform-checksums.json "${{env.RELEASE_LOCATION}}/v${{env.RELEASE_VERSION}}/secure-setup-terraform_${{env.RELEASE_VERSION}}_checksums.json"
-        tar xf secure-setup-terraform_${{env.RELEASE_VERSION}}_linux_${ARCH}.tar.gz
+        OS="${{ runner.os }}"
+        case "${OS}" in
+          Linux)
+            GOOS="linux"
+            EXT="tar.gz"
+            ;;
+          macOS)
+            GOOS="darwin"
+            EXT="tar.gz"
+            ;;
+          Windows)
+            GOOS="windows"
+            EXT="zip"
+            ;;
+          *)
+            echo "Unsupported OS: ${OS}" >&2
+            exit 1
+            ;;
+        esac
+
+        FILENAME="secure-setup-terraform_${RELEASE_VERSION}_${GOOS}_${ARCH}.${EXT}"
+        DOWNLOAD_URL="${RELEASE_LOCATION}/v${RELEASE_VERSION}/${FILENAME}"
+        echo "Attempting to download ${DOWNLOAD_URL}..."
+
+        if curl -sSLf -H "Authorization: token ${{ github.token }}" -O "${DOWNLOAD_URL}"; then
+          echo "Downloaded release binary."
+          curl -sSL -H "Authorization: token ${{ github.token }}" -Lo terraform-checksums.json "${RELEASE_LOCATION}/v${RELEASE_VERSION}/secure-setup-terraform_${RELEASE_VERSION}_checksums.json"
+          if [ "${EXT}" = "zip" ]; then
+            unzip -o "${FILENAME}"
+          else
+            tar xf "${FILENAME}"
+          fi
+        else
+          echo "WARNING: Release binary not found. Building from source..."
+          if ! command -v go &> /dev/null; then
+            echo "Error: Go is not installed, cannot build from source." >&2
+            exit 1
+          fi
+          ACTION_DIR="${{ github.action_path }}"
+          go build -C "${ACTION_DIR}" -o "$(pwd)/lint-terraform" ./cmd/lint-terraform
+          go build -C "${ACTION_DIR}" -o "$(pwd)/lint-action" ./cmd/lint-action
+          if [ ! -f "terraform-checksums.json" ]; then
+            cp "${ACTION_DIR}/terraform-checksums.json" .
+          fi
+        fi
+
+        # Add current directory to GITHUB_PATH so we can run lint-terraform/lint-action
+        echo "$(pwd)" >> "${GITHUB_PATH}"
 
         # Verify the terraform binary checksum
-        CHECKSUM=$(jq -r --arg version ${{ inputs.terraform_version }} '.versions[] | select(.version==$version and .arch=="'${ARCH}'" and .os=="linux") | .binary_checksum' < terraform-checksums.json)
+        CHECKSUM=$(jq -r --arg version ${{ inputs.terraform_version }} '.versions[] | select(.version==$version and .arch=="'${ARCH}'" and .os=="'${GOOS}'") | .binary_checksum' < terraform-checksums.json)
 
         # The terraform wrapper installs the actual binary as terraform-bin, check
         # for its existence and verify its checksum. Otherwise look for the default
-        # terrafrom binary
-        if [ -f "$(which terraform-bin)" ];
-        then
-          echo "${CHECKSUM}  $(which terraform-bin)" > terraform.sha256
+        # terraform binary
+        TF_PATH=$(which terraform-bin 2>/dev/null || which terraform 2>/dev/null)
+        if [ -n "${TF_PATH}" ]; then
+          echo "${CHECKSUM}  ${TF_PATH}" > terraform.sha256
         else
-          echo "${CHECKSUM}  $(which terraform)" > terraform.sha256
+          echo "Could not find terraform binary" >&2
+          exit 1
         fi
         shasum --algorithm 256 --check terraform.sha256
 
@@ -90,13 +137,13 @@ runs:
       env:
         LOCATION: '${{inputs.terraform_module_location}}'
       run: |-
-        ./lint-terraform ${{env.LOCATION}}
+        lint-terraform ${{env.LOCATION}}
 
     # Search the .github/workflows for this project and run a linter that fails if it finds a direct call to the 'hashicorp/setup-terraform' action
     - name: 'lint-action'
       shell: 'bash'
       run: |-
-        ./lint-action ./.github/workflows
+        lint-action ./.github/workflows
 
     # Mark the provider file readonly so that new providers cannot be added during actuation
     - name: 'lock-provider-file'


### PR DESCRIPTION
Will need to release other os binary checksums and update the integration tests.